### PR TITLE
feat: Add resizeModeProps to FastImage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,15 @@ It accepts every `Image` and `FastImage` props. You can use it like you used to.
 
 useNativeDriver?: boolean;
 
-| Property              |        Type         |  Default  | Description                           |
-| --------------------- | :-----------------: | :-------: | ------------------------------------- |
-| source                |       Source        | undefined | set the main source of the image      |
-| thumbnailSource       | ImageSourcePropType | undefined | set the thumbnail source of the image |
-| loadingSource         | ImageSourcePropType | undefined | set the error source of the image     |
-| errorSource           | ImageSourcePropType | undefined | set the loading source of the image   |
-| loadingImageComponent |      Component      |  default  | WARNING: Read the below!              |
-| blurRadius            |       number        |    15     | change the blur radius level          |
+| Property              |        Type               |  Default                  | Description                           |
+| --------------------- | :-----------------:       | :-------:                 | ------------------------------------- |
+| source                |       Source              | undefined                 | set the main source of the image      |
+| thumbnailSource       | ImageSourcePropType       | undefined                 | set the thumbnail source of the image |
+| loadingSource         | ImageSourcePropType       | undefined                 | set the error source of the image     |
+| errorSource           | ImageSourcePropType       | undefined                 | set the loading source of the image   |
+| loadingImageComponent |      Component            |  default                  | WARNING: Read the below!              |
+| blurRadius            |       number              |    15                     | change the blur radius level          |
+| resizeMode            |FastImageResizeModePropType| FastImage.resizeMode.cover| change the resize mode of the image   |
 
 ### `loadingImageComponent` Usage
 

--- a/lib/ProgressiveFastImage.tsx
+++ b/lib/ProgressiveFastImage.tsx
@@ -9,6 +9,7 @@ import {
 import FastImage, {
   ImageStyle as FastImageStyle,
   Source,
+  ResizeMode
 } from "react-native-fast-image";
 const AnimatedFastImage = Animated.createAnimatedComponent(FastImage);
 /**
@@ -36,6 +37,7 @@ export interface IProgressiveFastImageProps {
   thumbnailAnimationDuration?: number;
   imageAnimationDuration?: number;
   useNativeDriver?: boolean;
+  resizeMode?: ResizeMode;
 }
 
 interface IState {
@@ -124,6 +126,7 @@ class ProgressiveImage extends React.Component<
       loadingImageComponent,
       blurRadius = 15,
       loadingImageStyle,
+      resizeMode
       ...props
     } = this.props;
 
@@ -155,6 +158,7 @@ class ProgressiveImage extends React.Component<
           onLoadEnd={this.onLoadEnd}
           style={[styles.imageStyle, { opacity: this.animatedImage }, style]}
           source={this.statedSource()}
+          resizeMode={resizeMode ? resizeMode : FastImage.resizeMode.cover}
         />
       </View>
     );


### PR DESCRIPTION
Update Prop Types to fix issue:
Property 'resizeMode' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes & Readonly & Readonly<...>'.

This issue comes while create tsx components with the resizeMethod prop.

Example: resizeMode={FastImage.resizeMode.contain}

![https://user-images.githubusercontent.com/63907092/189483787-58c31423-999b-44a3-b8d3-718fdbde7491.png](https://user-images.githubusercontent.com/63907092/189483787-58c31423-999b-44a3-b8d3-718fdbde7491.png)
