### PR TITLE
fix: Property 'resizeMode' does not exist on type.

### DIFF
--- a/lib/ProgressiveFastImage.tsx
+++ b/lib/ProgressiveFastImage.tsx
@@ -36,6 +36,7 @@ export interface IProgressiveFastImageProps {
   thumbnailAnimationDuration?: number;
   imageAnimationDuration?: number;
   useNativeDriver?: boolean;
+  props?: FastImageProps
 }
 
 interface IState {


### PR DESCRIPTION
Update Prop Types to fix issue:
Property 'resizeMode' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<ProgressiveImage> & Readonly<IProgressiveFastImageProps> & Readonly<...>'.

This issue comes while create tsx components with the ```resizeMethod``` prop.

Example: ```resizeMode={FastImage.resizeMode.contain}```

<img width="1012" alt="Screenshot 2022-09-10 at 6 10 13 PM" src="https://user-images.githubusercontent.com/63907092/189483787-58c31423-999b-44a3-b8d3-718fdbde7491.png">

